### PR TITLE
Add support for Weave and Calico CNIs.

### DIFF
--- a/scr/kindbox
+++ b/scr/kindbox
@@ -647,6 +647,14 @@ function docker_iface_mtu() {
   local dockerCfgFile="${dockerCfgDir}/daemon.json"
   local default_mtu=1500
 
+  # Parsing the Docker config file requires root privilege; if we don't have it,
+  # skip.
+  user=$(whoami)
+  if [[ "$user" != "root" ]]; then
+	  echo $default_mtu
+	  return
+  fi
+
   if jq --exit-status 'has("mtu")' ${dockerCfgFile} >/dev/null; then
     local mtu=$(jq --exit-status '."mtu"' ${dockerCfgFile} 2>&1)
 
@@ -858,7 +866,7 @@ function list_clusters() {
   done
 
   if [[ $LONG_LIST == 1 ]]; then
-    local FORMAT="%-22s %-15s %-20s %-30s %-8s\n"
+    local FORMAT="%-22s %-15s %-20s %-40s %-8s\n"
     printf "$FORMAT" "NAME" "WORKERS" "NET" "IMAGE" "K8S VERSION"
 
     for cl in ${clusters[@]}; do
@@ -1206,8 +1214,8 @@ function show_usage() {
   printf "\n"
   printf "Moreover, the resulting K8s cluster boots up pretty quickly (< 2 minutes for a\n"
   printf "10-node cluster), uses minimal resources (only 1 GB overhead for a 10-node\n"
-  printf "cluster!), and does **not** use privileged containers (i.e., it's much more\n"
-  printf "secure).\n"
+  printf "cluster with Sysbox Enterprise!), and does **not** use privileged containers\n"
+  printf "(i.e., it's much more secure).\n"
   printf "\n"
   printf "Commands:\n"
   printf "  create      Creates a cluster.\n"

--- a/scr/kindbox
+++ b/scr/kindbox
@@ -29,9 +29,10 @@ set +e
 VERSION=v0.1
 
 CLUSTER_NAME=k8s-cluster
+CLUSTER_CNI=flannel
 NUM_WORKERS=1
-IMAGE=nestybox/k8s-node:v1.18.2
-K8S_VERSION=v1.18.2
+IMAGE=ghcr.io/nestybox/k8s-node:v1.20.2
+K8S_VERSION=v1.20.2
 
 VERBOSE=1
 PUBLISH=0
@@ -160,6 +161,87 @@ function flannel_config() {
   fi
 }
 
+function flannel_unconfig() {
+  local node=$1
+  local output
+
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl delete -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+}
+
+function weave_config() {
+  local node=$1
+  local output
+
+  # Fetch and apply Weave's manifest. Make sure the CIDR block matches the one
+  # utilized by the cluster for the pod-network range.
+  output=$(docker exec ${node} sh -c "kubectl apply -f https://cloud.weave.works/k8s/net?k8s-version=\$(kubectl version | base64 | tr -d '\n')\&env.IPALLOC_RANGE=10.244.0.0/16" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+}
+
+function weave_unconfig() {
+  local node=$1
+  local output
+
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl delete -f https://cloud.weave.works/k8s/net?k8s-version=${K8S_VERSION}\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+}
+
+function calico_config() {
+  local node=$1
+  local output
+
+  # Install the Tigera Calico operator.
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+
+  # Fetch Calico's CRD manifest and adjust its CIDR block to match the one
+  # utilized by the cluster for the pod-network range.
+  output=$(sh -c "docker exec ${node} sh -c \"curl https://docs.projectcalico.org/manifests/custom-resources.yaml --output calico-crd.yaml; sed -i 's/cidr: 192.168.0.0\/16/cidr: 10.244.0.0\/16/' calico-crd.yaml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+
+  # Deploy Calico's CRD.
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl create -f calico-crd.yaml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+}
+
+function calico_unconfig() {
+  local node=$1
+  local output
+
+  # Install Calico CRDs.
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl delete -f calico-crd.yaml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+
+  # Install the Tigera Calico operator.
+  output=$(sh -c "docker exec ${node} sh -c \"kubectl delete -f https://docs.projectcalico.org/manifests/tigera-operator.yaml\"" 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$output"
+    return 1
+  fi
+}
+
 function docker_pull_image() {
 
   # If the image is present, no action
@@ -221,7 +303,7 @@ function k8s_master_init() {
 
   [[ $VERBOSE ]] && printf "  - Running kubeadm init on $node ... (may take up to a minute)\n"
 
-  output=$(sh -c "docker exec ${node} sh -c \"kubeadm init --kubernetes-version=v1.18.2 --pod-network-cidr=10.244.0.0/16 2>&1\"" 2>&1)
+  output=$(sh -c "docker exec ${node} sh -c \"kubeadm init --kubernetes-version=${K8S_VERSION} --pod-network-cidr=10.244.0.0/16 2>&1\"" 2>&1)
   if [[ $? -ne 0 ]]; then
     ERR="kubadm init failed on ${node}: ${output}"
     return 1
@@ -241,20 +323,27 @@ function k8s_master_init() {
     return 1
   fi
 
-  [[ $VERBOSE ]] && printf "  - Initializing networking (flannel) on $node ...\n"
+  [[ $VERBOSE ]] && printf "  - Initializing networking (${CLUSTER_CNI} cni) on $node ...\n"
 
-  output=$(flannel_config ${node})
+  if [[ ${CLUSTER_CNI} == "flannel" ]]; then
+    output=$(flannel_config ${node})
+  elif [[ ${CLUSTER_CNI} == "weave" ]]; then
+    output=$(weave_config ${node})
+  elif [[ ${CLUSTER_CNI} == "calico" ]]; then
+    output=$(calico_config ${node})
+  fi
+
   if [[ $? -ne 0 ]]; then
-    ERR="flannel init failed on ${node}: ${output}"
-    return 1
+   ERR="cni init failed on ${node}: ${output}"
+   return 1
   fi
 
   [[ $VERBOSE ]] && printf "  - Waiting for $node to be ready ...\n"
 
   output=$(wait_for_node_ready ${node})
   if [[ $? -ne 0 ]]; then
-    ERR="${node} did not reach ready state: ${output}"
-    return 1
+   ERR="${node} did not reach ready state: ${output}"
+   return 1
   fi
 }
 
@@ -304,7 +393,7 @@ function k8s_workers_create() {
 
     output=$(sh -c "docker run --runtime=sysbox-runc -d --rm --network=$NET --name=${node} --hostname=${node} $IMAGE" 2>&1)
     if [[ $? -ne 0 ]]; then
-      k8s_workers_destroy $start $(($i + 1))
+      k8s_nodes_destroy $start $(($i + 1))
       ERR="failed to deploy node $node: $output"
       return 1
     fi
@@ -558,7 +647,7 @@ function docker_iface_mtu() {
   local dockerCfgFile="${dockerCfgDir}/daemon.json"
   local default_mtu=1500
 
-  if jq --exit-status 'has("mtu")' ${dockerCfgFile} >/dev/null 2>&1; then
+  if jq --exit-status 'has("mtu")' ${dockerCfgFile} >/dev/null; then
     local mtu=$(jq --exit-status '."mtu"' ${dockerCfgFile} 2>&1)
 
     if [ ! -z "$mtu" ] && [ "$mtu" -lt 1500 ]; then
@@ -581,6 +670,7 @@ function create_cluster() {
 
     printf "$FORMAT" "Cluster name" "${CLUSTER_NAME}"
     printf "$FORMAT" "Worker nodes" "${NUM_WORKERS}"
+    printf "$FORMAT" "CNI" "${CLUSTER_CNI}"
     printf "$FORMAT" "Docker network" "${NET}"
     printf "$FORMAT" "Node image" "${IMAGE}"
     printf "$FORMAT" "K8s version" "${K8S_VERSION}"
@@ -602,8 +692,8 @@ function create_cluster() {
 
   cluster_init_nodes
   if [[ $? -ne 0 ]]; then
-    cluster_destroy_nodes
     printf "ERROR: failed to initialize nodes: $ERR\n"
+    [[ $CLUSTER_RETAIN ]] || cluster_destroy_nodes
     exit 1
   fi
 
@@ -817,17 +907,19 @@ function show_create() {
   printf "  -h, --help                  Display usage.\n"
   printf "      --num-workers=<num>     Number of worker nodes (default = 1).\n"
   printf "      --net=<name>            Docker bridge network to connect the cluster to; if it does not exist, it will be created (default = 'CLUSTER_NAME-net').\n"
+  printf "      --cni=<cni-name>        Container Network Interface (CNI) to deploy; supported CNIs: flannel (default), weave and calico. The last two require Sysbox-Enterprise.\n"
   printf "      --image=<name>          Docker image for the cluster nodes (default = ${IMAGE}).\n"
   printf "      --k8s-version=<name>    Kubernetes version; must correspond to the version of K8s embeddeded in the image.\n"
   printf "  -p, --publish=<port>        Publish the cluster's apiserver port via a host port; allows for remote control of the cluster.\n"
   printf "  -w, --wait-all              Wait for all nodes in the cluster to be ready; if not set, this command completes once the master node is ready (worker nodes may not be ready).\n"
+  printf "  -r, --retain                Avoid destroying all the nodes if cluster-creation process fails at a late stage -- useful for debugging purposes (unset by default).\n"
   exit 1
 }
 
 function parse_create_args() {
   local new_net="true"
 
-  options=$(getopt -o p:wh -l wait-all,help,num-workers::,net::,image::,k8s-version::,publish:: -- "$@")
+  options=$(getopt -o p:whr -l wait-all,retain,help,num-workers::,net::,cni::,image::,k8s-version::,publish:: -- "$@")
 
   [ $? -eq 0 ] || {
     show_create
@@ -853,6 +945,10 @@ function parse_create_args() {
         NET=$1
         new_net="false"
         ;;
+      --cni)
+        shift;
+        CLUSTER_CNI=$1
+        ;;
       --image)
         shift;
         IMAGE=$1
@@ -863,6 +959,9 @@ function parse_create_args() {
         ;;
       -w | --wait-all)
         WAIT_READY=1
+        ;;
+      -r | --retain)
+        CLUSTER_RETAIN=1
         ;;
       -p | --publish)
         PUBLISH=1
@@ -891,6 +990,16 @@ function parse_create_args() {
 
   if [[ $new_net == "true" ]]; then
      NET="${CLUSTER_NAME}-net"
+  fi
+
+  if [[ $CLUSTER_CNI == "" ]]; then
+    CLUSTER_CNI="flannel"
+  elif
+    [[ ${CLUSTER_CNI} != "flannel" ]] &&
+    [[ ${CLUSTER_CNI} != "weave" ]] &&
+    [[ ${CLUSTER_CNI} != "calico" ]]; then
+    printf "Unsupported CNI: \"${CLUSTER_CNI}\". Enter one of the supported CNIs: flannel, weave, calico\n"
+    exit 1
   fi
 }
 
@@ -962,7 +1071,7 @@ function show_resize() {
   printf "Options:\n"
   printf "      --num-workers=<num>     Desired number of total worker nodes in the cluster.\n"
   printf "      --image=<name>          When increasing the size of the cluster, the Docker image for the new worker nodes (default = the image used when cluster was created).\n"
-  printf "  -w, --wait-all              When increasing the size of the clsuter, wait for newly added nodes in the cluster to be ready; if not set, this command completes before the nodes may be ready).\n"
+  printf "  -w, --wait-all              When increasing the size of the cluster, wait for newly added nodes in the cluster to be ready; if not set, this command completes before the nodes may be ready).\n"
   printf "  -h, --help                  Display usage.\n"
   exit 1
 }


### PR DESCRIPTION
This commit adds support for deploying K8s-in-Docker clusters that use the Weave
or Calico CNIs. Note that both of these require Sysbox Enterprise Edition
(Sysbox-EE).

Bonus: bump up the K8s version from v1.18.2 -> v1.20.2.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>